### PR TITLE
Maintenance/macos file ignoring

### DIFF
--- a/Unity - TownOne2023Team5/.gitignore
+++ b/Unity - TownOne2023Team5/.gitignore
@@ -90,3 +90,6 @@ crashlytics-build.properties
 # If the source bank files are kept outside of the StreamingAssets folder then these can be ignored.
 # Log files can be ignored.
 fmod_editor.log
+
+# MacOS specific files
+*.DS_Store

--- a/Unity - TownOne2023Team5/Assets/Scenes/MainSceneDevToMerge.unity.meta
+++ b/Unity - TownOne2023Team5/Assets/Scenes/MainSceneDevToMerge.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 66b4e83389de29a4caeda2d6d271128c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a line to the `.gitignore` for macOS generated image index files.