### PR TITLE
Ignore macOS generated image index files

### DIFF
--- a/Unity - TownOne2023Team5/.gitignore
+++ b/Unity - TownOne2023Team5/.gitignore
@@ -90,3 +90,6 @@ crashlytics-build.properties
 # If the source bank files are kept outside of the StreamingAssets folder then these can be ignored.
 # Log files can be ignored.
 fmod_editor.log
+
+# MacOS specific files
+*.DS_Store


### PR DESCRIPTION
Adds a line to the .gitignore for macOS generated image index files.