### PR TITLE
Feature: Day night cycle UI

### DIFF
--- a/Unity - TownOne2023Team5/Assets/Prefabs/GameManager.prefab
+++ b/Unity - TownOne2023Team5/Assets/Prefabs/GameManager.prefab
@@ -37,6 +37,7 @@ Transform:
   - {fileID: 2814020212406194766}
   - {fileID: 6296989567908457151}
   - {fileID: 4878327447511869771}
+  - {fileID: 8728835442684853137}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -184,6 +185,72 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 6968503820746812925, guid: e0fa0b38530eced42bfe2fd1af86629e, type: 3}
   m_PrefabInstance: {fileID: 1408327948310274531}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3653625741089689611
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7515395236938101048}
+    m_Modifications:
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8306037870623836925, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+      propertyPath: m_Name
+      value: TimeMgr
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+--- !u!4 &8728835442684853137 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5446897962654247834, guid: 5cb9b8e77f0e7614086d9ac3df2d63c4, type: 3}
+  m_PrefabInstance: {fileID: 3653625741089689611}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4517636239918100355
 PrefabInstance:

--- a/Unity - TownOne2023Team5/Assets/Prefabs/In-Game Overlay.prefab
+++ b/Unity - TownOne2023Team5/Assets/Prefabs/In-Game Overlay.prefab
@@ -35,7 +35,7 @@ RectTransform:
   - {fileID: 8257470764524892699}
   - {fileID: 3652736398886658814}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -133,8 +133,8 @@ RectTransform:
   m_GameObject: {fileID: 1529482371453400664}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.52, y: 1.52, z: 1.52}
+  m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 2143243363299555910}
   - {fileID: 6501656267594401594}
@@ -144,7 +144,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -678, y: 8}
+  m_AnchoredPosition: {x: -889, y: 19}
   m_SizeDelta: {x: 1920, y: 1038}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &154803416587673481
@@ -388,7 +388,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 23, y: -160}
-  m_SizeDelta: {x: 200, y: 50}
+  m_SizeDelta: {x: 139, y: 50}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3914209246000308070
 CanvasRenderer:
@@ -452,7 +452,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -1017,7 +1017,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 3652736398886658814}
   m_RootOrder: -1

--- a/Unity - TownOne2023Team5/Assets/Prefabs/In-Game Overlay.prefab
+++ b/Unity - TownOne2023Team5/Assets/Prefabs/In-Game Overlay.prefab
@@ -116,8 +116,9 @@ GameObject:
   - component: {fileID: 3652736398886658814}
   - component: {fileID: 154803416587673481}
   - component: {fileID: 2607652391650228450}
+  - component: {fileID: 6761625767485225314}
   m_Layer: 5
-  m_Name: Timerpanel
+  m_Name: Timepanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -143,7 +144,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -746, y: 1}
+  m_AnchoredPosition: {x: -678, y: 8}
   m_SizeDelta: {x: 1920, y: 1038}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &154803416587673481
@@ -184,6 +185,21 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6761625767485225314
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1529482371453400664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cea73be2786d8aa499b1d66508cb2ca5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentAngle: 0
+  TimeUnderlay: {fileID: 2143243363299555910}
+  TimeAmtText: {fileID: 2502197448488417124}
 --- !u!1 &2419515087837307410
 GameObject:
   m_ObjectHideFlags: 0
@@ -371,7 +387,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 179.79, y: -61.08}
+  m_AnchoredPosition: {x: 23, y: -160}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3914209246000308070

--- a/Unity - TownOne2023Team5/Assets/Prefabs/In-Game Overlay.prefab
+++ b/Unity - TownOne2023Team5/Assets/Prefabs/In-Game Overlay.prefab
@@ -33,8 +33,9 @@ RectTransform:
   m_Children:
   - {fileID: 8992327374088642915}
   - {fileID: 8257470764524892699}
+  - {fileID: 3652736398886658814}
   m_Father: {fileID: 0}
-  m_RootOrder: -1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -104,6 +105,161 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!1 &1529482371453400664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3652736398886658814}
+  - component: {fileID: 154803416587673481}
+  - component: {fileID: 2607652391650228450}
+  m_Layer: 5
+  m_Name: Timerpanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3652736398886658814
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1529482371453400664}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2143243363299555910}
+  - {fileID: 6501656267594401594}
+  - {fileID: 9038555875511199487}
+  m_Father: {fileID: 6944525085370043082}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -746, y: 1}
+  m_SizeDelta: {x: 1920, y: 1038}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &154803416587673481
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1529482371453400664}
+  m_CullTransparentMesh: 1
+--- !u!114 &2607652391650228450
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1529482371453400664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2419515087837307410
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6501656267594401594}
+  - component: {fileID: 2793822523660086576}
+  - component: {fileID: 9089771717507486238}
+  m_Layer: 5
+  m_Name: TimeOverlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6501656267594401594
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2419515087837307410}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3652736398886658814}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 20, y: -15.66}
+  m_SizeDelta: {x: 142, y: 136.85715}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &2793822523660086576
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2419515087837307410}
+  m_CullTransparentMesh: 1
+--- !u!114 &9089771717507486238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2419515087837307410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 88d959fb662767d40b61a7cf71eb6828, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2685633957290663773
 GameObject:
   m_ObjectHideFlags: 0
@@ -180,6 +336,141 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3176466954936872002
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9038555875511199487}
+  - component: {fileID: 3914209246000308070}
+  - component: {fileID: 2502197448488417124}
+  m_Layer: 5
+  m_Name: TimeAmtText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9038555875511199487
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3176466954936872002}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3652736398886658814}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 179.79, y: -61.08}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &3914209246000308070
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3176466954936872002}
+  m_CullTransparentMesh: 1
+--- !u!114 &2502197448488417124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3176466954936872002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Time
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: d38f3ba05cae8a247beee1159f008f91, type: 2}
+  m_sharedMaterial: {fileID: -6305061933454196885, guid: d38f3ba05cae8a247beee1159f008f91, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &3366634818152726365
 GameObject:
   m_ObjectHideFlags: 0
@@ -682,3 +973,79 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7731944032239877398
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2143243363299555910}
+  - component: {fileID: 5256498017097658973}
+  - component: {fileID: 4635389698114029784}
+  m_Layer: 5
+  m_Name: TimeUnderlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2143243363299555910
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7731944032239877398}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3652736398886658814}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -869, y: 434.91144}
+  m_SizeDelta: {x: 142, y: 136.85715}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5256498017097658973
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7731944032239877398}
+  m_CullTransparentMesh: 1
+--- !u!114 &4635389698114029784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7731944032239877398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 988996bf40720904199876244bc721e3, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Unity - TownOne2023Team5/Assets/Prefabs/TimeMgr.prefab
+++ b/Unity - TownOne2023Team5/Assets/Prefabs/TimeMgr.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8306037870623836925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5446897962654247834}
+  - component: {fileID: 6860103619009512520}
+  m_Layer: 0
+  m_Name: TimeMgr
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5446897962654247834
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8306037870623836925}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6860103619009512520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8306037870623836925}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4042cd1beef2e74cad12cdaad31c690, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Unity - TownOne2023Team5/Assets/Prefabs/TimeMgr.prefab.meta
+++ b/Unity - TownOne2023Team5/Assets/Prefabs/TimeMgr.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5cb9b8e77f0e7614086d9ac3df2d63c4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity - TownOne2023Team5/Assets/Scenes/MainSceneMusic.unity
+++ b/Unity - TownOne2023Team5/Assets/Scenes/MainSceneMusic.unity
@@ -1331,6 +1331,14 @@ PrefabInstance:
       propertyPath: <nightCycleDuration>k__BackingField
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 8611046780331613074, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -173
+      objectReference: {fileID: 0}
+    - target: {fileID: 8611046780331613074, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 8
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:

--- a/Unity - TownOne2023Team5/Assets/Scenes/MainSceneMusic.unity
+++ b/Unity - TownOne2023Team5/Assets/Scenes/MainSceneMusic.unity
@@ -1215,6 +1215,18 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6381567074409792298, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381567074409792298, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6381567074409792298, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 180
+      objectReference: {fileID: 0}
     - target: {fileID: 6466908263358686678, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
       propertyPath: m_Pivot.x
       value: 1
@@ -1298,6 +1310,26 @@ PrefabInstance:
     - target: {fileID: 7515395236938101048, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7892473297264235587, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: dayCycleDuration
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7892473297264235587, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: nightCycleDuration
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7892473297264235587, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: <isDayTime>k__BackingField
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7892473297264235587, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: <dayCycleDuration>k__BackingField
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7892473297264235587, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
+      propertyPath: <nightCycleDuration>k__BackingField
+      value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Unity - TownOne2023Team5/Assets/Scenes/MainSceneMusic.unity
+++ b/Unity - TownOne2023Team5/Assets/Scenes/MainSceneMusic.unity
@@ -1325,19 +1325,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7892473297264235587, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
       propertyPath: <dayCycleDuration>k__BackingField
-      value: 5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7892473297264235587, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
       propertyPath: <nightCycleDuration>k__BackingField
-      value: 5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8611046780331613074, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -173
+      value: -270
       objectReference: {fileID: 0}
     - target: {fileID: 8611046780331613074, guid: cd51c0374405ce14ca9b32c3c08370d0, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 8
+      value: 23
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs
+++ b/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs
@@ -20,9 +20,9 @@ public class TimeMgr : Singleton<TimeMgr>
 	  	base.Awake();
   	}
     
-    void FixedUpdate()
+    void Update()
     {
-      currentTime += Time.fixedDeltaTime;
+      currentTime += Time.deltaTime;
       var cycleDuration = isDayTime ? dayCycleDuration : nightCycleDuration;
       
       if (currentTime > cycleDuration) {

--- a/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs
+++ b/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs
@@ -4,18 +4,32 @@ using UnityEngine;
 
 public class TimeMgr : Singleton<TimeMgr>
 {
-    [SerializeField]
-    private float currentTime;
+    [field: SerializeField]
+    public float currentTime {get; private set;}
     
-    [SerializeField]
-    private float nightCycleDuration;
-    [SerializeField]
-    private float dayCycleDuration;
-    [SerializeField]
-    private bool isDayTime = true;
-    override protected void Awake() {
-		base.Awake();
+    [field: SerializeField]
+    public float nightCycleDuration {get; private set;}
 
-	}
+    [field: SerializeField]
+    public float dayCycleDuration {get; private set;}
+
+    [field: SerializeField]
+    public bool isDayTime {get; private set;} = true;
+
+    override protected void Awake() {
+	  	base.Awake();
+  	}
+    
+    void FixedUpdate()
+    {
+      currentTime += Time.fixedDeltaTime;
+      var cycleDuration = isDayTime ? dayCycleDuration : nightCycleDuration;
+      
+      if (currentTime > cycleDuration) {
+          // TODO call some callback function
+          isDayTime = !isDayTime;
+          currentTime %= cycleDuration;
+      }
+    }
 
 }

--- a/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs
+++ b/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TimeMgr : Singleton<TimeMgr>
+{
+    [SerializeField]
+    private float currentTime;
+    
+    [SerializeField]
+    private float nightCycleDuration;
+    [SerializeField]
+    private float dayCycleDuration;
+    [SerializeField]
+    private bool isDayTime = true;
+    override protected void Awake() {
+		base.Awake();
+
+	}
+
+}

--- a/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs.meta
+++ b/Unity - TownOne2023Team5/Assets/Scripts/Managers/TimeMgr.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4042cd1beef2e74cad12cdaad31c690
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity - TownOne2023Team5/Assets/Scripts/TimePanel.cs
+++ b/Unity - TownOne2023Team5/Assets/Scripts/TimePanel.cs
@@ -33,12 +33,7 @@ public class TimePanel : MonoBehaviour
         else
             currentAngle = nightStartAngle + 180.0f * currentTime / TimeMgr.Instance.nightCycleDuration;
         
-        if (currentAngle > oldAngle) {
-            Debug.Log("Rotated to currentAngle.");
-            TimeUnderlay.Rotate(new Vector3(0.0f, 0.0f, currentAngle - oldAngle));
-        } else {
-            Debug.Log("Rotated to oldAngle.");
-            TimeUnderlay.Rotate(new Vector3(0.0f, 0.0f, oldAngle - currentAngle));
-        }
+        Debug.Log("Rotated to current angle");
+        TimeUnderlay.Rotate(new Vector3(0.0f, 0.0f, currentAngle - oldAngle));
     }
 }

--- a/Unity - TownOne2023Team5/Assets/Scripts/TimePanel.cs
+++ b/Unity - TownOne2023Team5/Assets/Scripts/TimePanel.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TimePanel : MonoBehaviour
+{
+    [SerializeField]
+    private float currentAngle = 0.0f;
+    [SerializeField]
+    private const float dayStartAngle = 180.0f;  
+    [SerializeField]
+    private const float nightStartAngle = 360.0f;
+    [SerializeField]
+    private Transform TimeUnderlay;
+    [SerializeField]
+    private TMPro.TMP_Text TimeAmtText;
+
+    void Start ()
+    {
+        if (TimeMgr.Instance.isDayTime)
+            currentAngle = dayStartAngle;
+        else 
+            currentAngle = nightStartAngle;
+    }
+    // Update is called once per frame
+    void Update()
+    {
+        var currentTime = TimeMgr.Instance.currentTime;
+        TimeAmtText.text = currentTime.ToString();
+        var oldAngle = currentAngle;
+        if (TimeMgr.Instance.isDayTime)
+            currentAngle = dayStartAngle + 180.0f * currentTime / TimeMgr.Instance.dayCycleDuration;
+        else
+            currentAngle = nightStartAngle + 180.0f * currentTime / TimeMgr.Instance.nightCycleDuration;
+        
+        if (currentAngle > oldAngle) {
+            Debug.Log("Rotated to currentAngle.");
+            TimeUnderlay.Rotate(new Vector3(0.0f, 0.0f, currentAngle - oldAngle));
+        } else {
+            Debug.Log("Rotated to oldAngle.");
+            TimeUnderlay.Rotate(new Vector3(0.0f, 0.0f, oldAngle - currentAngle));
+        }
+    }
+}

--- a/Unity - TownOne2023Team5/Assets/Scripts/TimePanel.cs.meta
+++ b/Unity - TownOne2023Team5/Assets/Scripts/TimePanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cea73be2786d8aa499b1d66508cb2ca5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity - TownOne2023Team5/Packages/manifest.json
+++ b/Unity - TownOne2023Team5/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.feature.2d": "1.0.0",
     "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
+    "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.6.1",
     "com.unity.render-pipelines.universal": "14.0.8",
     "com.unity.test-framework": "1.1.33",

--- a/Unity - TownOne2023Team5/Packages/packages-lock.json
+++ b/Unity - TownOne2023Team5/Packages/packages-lock.json
@@ -156,6 +156,13 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.ide.vscode": {
+      "version": "1.2.5",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.inputsystem": {
       "version": "1.6.1",
       "depth": 0,


### PR DESCRIPTION
Part of #6 and resolves #59.

The current time will now be tracked in `TimeMgr`, which contains the following fields:
- `currentTime`, current time (seconds)
- `nightCycleDuration`, how long the night cycle is (seconds)
- `dayCycleDuration`, how long the day cycle is (seconds)
- `isDayTime`, `true` if the current cycle is day

I've also made a `Timepanel` child of the `In-Game Overlay` prefab that contains a timer:

https://github.com/InfiniteEchoDev/GreenerPastures/assets/38707101/e0052f2b-98bb-446e-93f6-25a579b20022

In the final game, the time text will either not be visible, or be converted into a realistic-looking (e.g. 11:30 -> 12:00 -> 12:30 -> 13:00, and so on).

